### PR TITLE
feat: add pull-to-refresh for PWA

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -173,6 +173,35 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const allItemIds = feedData.map(item => item.id);
     localStorage.setItem('seenItemIds', JSON.stringify(allItemIds));
+
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+    if (isStandalone) {
+        let startY = 0;
+        let isPulling = false;
+        const pullThreshold = 80;
+
+        document.addEventListener('touchstart', (e) => {
+            if (window.scrollY === 0) {
+                startY = e.touches[0].clientY;
+                isPulling = true;
+            }
+        }, { passive: true });
+
+        document.addEventListener('touchmove', (e) => {
+            if (!isPulling) {
+                return;
+            }
+            const currentY = e.touches[0].clientY;
+            if (currentY - startY > pullThreshold) {
+                window.location.reload();
+                isPulling = false;
+            }
+        }, { passive: true });
+
+        document.addEventListener('touchend', () => {
+            isPulling = false;
+        });
+    }
 });
 
 if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- add custom pull-to-refresh handling when running as a standalone PWA

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890e59b3144832f8bbde6839c3799f3