### PR TITLE
Highlight profile icon when viewing starred items

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -81,6 +81,10 @@ body {
     object-fit: cover;
 }
 
+.profile-image.starred-active {
+    box-shadow: 0 0 10px 3px gold;
+}
+
 #profile-link {
     display: inline-block;
     margin-top: var(--spacing-xlarge);

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     const profileLink = document.getElementById('profile-link');
+    const profileImage = document.getElementById('reload-icon');
     const feedContainer = document.getElementById('feed-container');
     let feedData = [];
     let showingStarred = false;
@@ -152,6 +153,9 @@ document.addEventListener('DOMContentLoaded', () => {
             e.preventDefault();
             showingStarred = !showingStarred;
             renderFeed(showingStarred ? 'starred' : 'all');
+            if (profileImage) {
+                profileImage.classList.toggle('starred-active', showingStarred);
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- Add gold glow effect to profile image when starred items are displayed.
- Toggle glow state via JavaScript when switching between all and starred feeds.

## Testing
- `node --check js/main.js`
- `python -m py_compile scripts/fetch_feeds.py`


------
https://chatgpt.com/codex/tasks/task_e_6890f3aac4f0832f81bb8491ffa791db