### PR TITLE
Add pull-to-refresh indicator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -62,6 +62,24 @@ body {
     user-select: none;
 }
 
+.pull-to-refresh {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background-color: var(--surface-color);
+    color: var(--primary-text-color);
+    text-align: center;
+    padding: var(--spacing-medium);
+    transform: translateY(-100%);
+    transition: transform 0.2s ease;
+    z-index: 1000;
+}
+
+.pull-to-refresh.visible {
+    /* transform controlled via JavaScript for dynamic pull distance */
+}
+
 #blink-text {
     font-size: 3em;
     font-weight: bold;

--- a/index.template.html
+++ b/index.template.html
@@ -35,6 +35,7 @@
     <meta name="msapplication-tap-highlight" content="no">
 </head>
 <body>
+    <div id="pull-to-refresh" class="pull-to-refresh">Pull to refresh</div>
     <div class="header">
         <a id="profile-link"><img src="images/icon.png" alt="Profile Image" class="profile-image" id="reload-icon"></a>
         <span id="blink-text">blink</span>

--- a/js/main.js
+++ b/js/main.js
@@ -168,12 +168,18 @@ document.addEventListener('DOMContentLoaded', () => {
     if (isStandalone) {
         let startY = 0;
         let isPulling = false;
+        let shouldRefresh = false;
         const pullThreshold = 80;
+        const maxPull = pullThreshold * 2;
+        const pullIndicator = document.getElementById('pull-to-refresh');
 
         document.addEventListener('touchstart', (e) => {
             if (window.scrollY === 0) {
                 startY = e.touches[0].clientY;
                 isPulling = true;
+                pullIndicator.classList.add('visible');
+                pullIndicator.textContent = 'Pull to refresh';
+                pullIndicator.style.transform = `translateY(-${pullIndicator.offsetHeight}px)`;
             }
         }, { passive: true });
 
@@ -182,14 +188,34 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             const currentY = e.touches[0].clientY;
-            if (currentY - startY > pullThreshold) {
-                window.location.reload();
-                isPulling = false;
+            const pullDistance = currentY - startY;
+            if (pullDistance < 0) {
+                return;
+            }
+            const translateY = Math.min(pullDistance * 2, maxPull) - pullIndicator.offsetHeight;
+            pullIndicator.style.transform = `translateY(${translateY}px)`;
+            if (pullDistance > pullThreshold) {
+                pullIndicator.textContent = 'Release to refresh';
+                shouldRefresh = true;
+            } else {
+                pullIndicator.textContent = 'Pull to refresh';
+                shouldRefresh = false;
             }
         }, { passive: true });
 
         document.addEventListener('touchend', () => {
+            if (isPulling) {
+                if (shouldRefresh) {
+                    pullIndicator.textContent = 'Refreshing...';
+                    pullIndicator.style.transform = `translateY(${pullThreshold - pullIndicator.offsetHeight}px)`;
+                    window.location.reload();
+                } else {
+                    pullIndicator.classList.remove('visible');
+                    pullIndicator.style.transform = '';
+                }
+            }
             isPulling = false;
+            shouldRefresh = false;
         });
     }
 });


### PR DESCRIPTION
## Summary
- show a pull-to-refresh hint text at the top of the PWA
- adjust styles so JavaScript controls the pull-to-refresh indicator
- update pull refresh logic to move the indicator twice as far while dragging

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m py_compile scripts/fetch_feeds.py`


------
https://chatgpt.com/codex/tasks/task_e_689126afc330832f9be0f6cb2707be4a