### PR TITLE
feat: double pull-to-refresh distance

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -77,7 +77,7 @@ body {
 }
 
 .pull-to-refresh.visible {
-    transform: translateY(0);
+    transform: translateY(100%);
 }
 
 #blink-text {

--- a/js/main.js
+++ b/js/main.js
@@ -169,7 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
         let startY = 0;
         let isPulling = false;
         let shouldRefresh = false;
-        const pullThreshold = 80;
+        const pullThreshold = 160;
         const pullIndicator = document.getElementById('pull-to-refresh');
 
         document.addEventListener('touchstart', (e) => {


### PR DESCRIPTION
## Summary
- double the required pull distance before triggering refresh in PWA mode
- slide the pull-to-refresh indicator farther down when activated

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689137f0481c832fb492686a0d050b11