### PR TITLE
Animate page during pull-to-refresh

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -178,6 +178,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 isPulling = true;
                 pullIndicator.classList.add('visible');
                 pullIndicator.textContent = 'Pull to refresh';
+                document.body.style.transition = 'none';
             }
         }, { passive: true });
 
@@ -186,7 +187,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             const currentY = e.touches[0].clientY;
-            const pullDistance = currentY - startY;
+            const pullDistance = Math.max(0, currentY - startY);
+            document.body.style.transform = `translateY(${pullDistance}px)`;
             if (pullDistance > pullThreshold) {
                 pullIndicator.textContent = 'Release to refresh';
                 shouldRefresh = true;
@@ -198,12 +200,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
         document.addEventListener('touchend', () => {
             if (isPulling) {
+                document.body.style.transition = 'transform 0.2s ease';
+                document.body.style.transform = 'translateY(0)';
                 if (shouldRefresh) {
                     pullIndicator.textContent = 'Refreshing...';
-                    window.location.reload();
+                    setTimeout(() => window.location.reload(), 200);
                 } else {
                     pullIndicator.classList.remove('visible');
                 }
+                setTimeout(() => {
+                    document.body.style.transition = '';
+                    document.body.style.transform = '';
+                }, 200);
             }
             isPulling = false;
             shouldRefresh = false;


### PR DESCRIPTION
## Summary
- Translate the page body while pulling to visually move content downward.
- Smoothly reset page position on release and reload when threshold exceeded.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68922257a0ec832f8214687cc82994c7