### PR TITLE
keep youtube feeds under youtube section

### DIFF
--- a/feeds.txt
+++ b/feeds.txt
@@ -245,4 +245,5 @@ https://www.youtube.com/feeds/videos.xml?channel_id=UCg0FSqPeiGD_lIiPaaAehQg
 https://www.youtube.com/feeds/videos.xml?channel_id=UCr613nJgA50o8DUUT00qHvw
 
 #youtube
+# t3dotgg
 https://www.youtube.com/@t3dotgg


### PR DESCRIPTION
## Summary
- keep YouTube RSS links in the `#youtube` section and record channel names as comments
- restructure URL parsing to preserve existing comments and move YouTube feeds out of the `#rss` section
- document the example channel in `feeds.txt`

## Testing
- `python -m py_compile scripts/fetch_feeds.py`


------
https://chatgpt.com/codex/tasks/task_e_6892510d5910832fa65d9db881c6b879