### PR TITLE
Ensure floating menu always visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -248,7 +248,8 @@ body {
 .floating-menu {
     position: fixed;
     right: var(--spacing-medium);
-    top: 50%;
+    /* Use viewport height so menu stays centered regardless of page length */
+    top: 50vh;
     transform: translateY(-50%);
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Center floating menu using viewport height so it shows whether viewing starred or unstarred items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892758c02c8832f8faf11ac5d42d396