### PR TITLE
Expand floating menu size and keep it fixed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -253,7 +253,7 @@ body {
     transform: translateY(-50%);
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-medium);
+    gap: var(--spacing-xlarge);
     z-index: 1000;
 }
 
@@ -262,7 +262,8 @@ body {
     color: var(--button-text-color);
     border: 1px solid var(--button-border-color);
     border-radius: var(--border-radius-small);
-    padding: var(--spacing-small);
+    padding: var(--spacing-medium);
+    font-size: 2rem;
     cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- Keep floating action menu fixed on the right side for visibility while scrolling
- Double the floating menu button size for easier access

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile scripts/fetch_feeds.py`

------
https://chatgpt.com/codex/tasks/task_e_6892792988fc832fa8be4daf64796568