### PR TITLE
fix: keep header visible on scroll

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -47,7 +47,6 @@ body {
     -webkit-overflow-scrolling: touch;
     position: relative;
     min-height: 100vh;
-    transform: translateZ(0);
 }
 
 .header {


### PR DESCRIPTION
## Summary
- remove hardware-acceleration transform from `body` so `.header` can stick to the top during scrolling

## Testing
- `python -m py_compile scripts/fetch_feeds.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892886eb940832fa72f431f4e557f5d