### PR TITLE
Show retention period and flag expiring feed items

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -202,6 +202,12 @@ body {
     font-style: italic;
 }
 
+.leaving-soon {
+    font-size: var(--font-size-small);
+    color: var(--accent-color);
+    font-style: italic;
+}
+
 .summary {
     font-size: 1em;
     color: var(--summary-text-color);

--- a/js/main.js
+++ b/js/main.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
             `;
         }
 
-
+        const leavingSoonHtml = item.leaving_soon ? '<p class="leaving-soon">Leaving soon</p>' : '';
 
         return `
             <div class="feed-item" data-item-id="${item.id}">
@@ -64,6 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     <h2><a href="${item.link}" target="_blank">${item.title}</a></h2>
                     <p class="published-date">${item.published}</p>
                     <p class="feed-title">${item.feed_title}</p>
+                    ${leavingSoonHtml}
                     ${summaryHtml}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- display item retention window next to last updated timestamp
- flag feed entries at the retention limit with a "Leaving soon" notice
- style "Leaving soon" indicator and render it in frontend

## Testing
- `python -m py_compile scripts/fetch_feeds.py`
- `node --check js/main.js`
- `python scripts/fetch_feeds.py` *(fails: ModuleNotFoundError: No module named 'feedparser')*
- `pip install feedparser requests beautifulsoup4 pytz` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68952450d90c832fa673a0a55651b380