### PR TITLE
Add leaving soon indicator to feed items

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -206,6 +206,10 @@ body {
     font-size: var(--font-size-small);
     color: var(--accent-color);
     font-style: italic;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
 }
 
 .summary {

--- a/js/main.js
+++ b/js/main.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
             `;
         }
 
-        const leavingSoonHtml = item.leaving_soon ? '<p class="leaving-soon">Leaving soon</p>' : '';
+        const leavingSoonHtml = item.leaving_soon ? '<p class="leaving-soon">⏰ Leaving soon</p>' : '';
 
         return `
             <div class="feed-item" data-item-id="${item.id}">

--- a/scripts/fetch_feeds.py
+++ b/scripts/fetch_feeds.py
@@ -245,10 +245,10 @@ class FeedProcessor:
                 continue
             
             # Determine if item is about to be removed within the next day
-            # We flag items that are at least ITEMS_RETENTION_DAYS days old
+            # Flag items that will reach the retention cutoff in one day
             is_leaving_soon = (
                 self.utc_now - published_time
-            ) >= timedelta(days=ITEMS_RETENTION_DAYS)
+            ) >= timedelta(days=ITEMS_RETENTION_DAYS - 1)
 
             # Convert to local timezone
             published_time = published_time.astimezone(self.local_tz)
@@ -368,7 +368,7 @@ class FeedProcessor:
 <p class="feed-title">{item["feed_title"]}</p>
 '''
         if item.get('leaving_soon'):
-            html += '<p class="leaving-soon">Leaving soon</p>\n'
+            html += '<p class="leaving-soon">⏰ Leaving soon</p>\n'
 
         if item['summary']:
             html += f'''<button class="toggle-summary-btn" data-target="summary-{item_id}">...</button>


### PR DESCRIPTION
## Summary
- highlight items flagged as leaving soon with a visible ⏰ tag
- style the indicator to stand out in the feed
- fix leaving soon logic so items within a day of expiration show the indicator

## Testing
- `python3 -m py_compile scripts/fetch_feeds.py`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_689533bf8e64832fbee4f10ffe620e48