### PR TITLE
Add picture-in-picture support for videos

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -398,6 +398,20 @@ html {
     height: 100%;
 }
 
+.video-placeholder .pip-button {
+    position: absolute;
+    bottom: var(--spacing-small);
+    right: var(--spacing-small);
+    background-color: rgba(0, 0, 0, 0.6);
+    color: var(--accent-color);
+    border: none;
+    border-radius: var(--border-radius-small);
+    padding: var(--spacing-small) var(--spacing-medium);
+    cursor: pointer;
+    z-index: 5;
+    font-size: var(--font-size-small);
+}
+
 
 
 .star-icon {

--- a/js/main.js
+++ b/js/main.js
@@ -136,15 +136,34 @@ document.addEventListener('DOMContentLoaded', () => {
                 const videoId = videoPlaceholder.getAttribute('data-video-id');
                 if (videoId) {
                     const iframe = document.createElement('iframe');
-                    iframe.setAttribute('src', `https://www.youtube.com/embed/${videoId}?autoplay=1`);
+                    iframe.setAttribute('src', `https://www.youtube.com/embed/${videoId}?autoplay=1&playsinline=1`);
                     iframe.setAttribute('frameborder', '0');
                     iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture');
                     iframe.setAttribute('allowfullscreen', '');
                     iframe.classList.add('video-iframe');
-                    
+
                     videoPlaceholder.innerHTML = '';
                     videoPlaceholder.appendChild(iframe);
                     videoPlaceholder.classList.add('video-loaded');
+
+                    if (document.pictureInPictureEnabled && typeof iframe.requestPictureInPicture === 'function') {
+                        const pipBtn = document.createElement('button');
+                        pipBtn.className = 'pip-button';
+                        pipBtn.textContent = '⧉';
+                        pipBtn.addEventListener('click', async (event) => {
+                            event.stopPropagation();
+                            try {
+                                if (document.pictureInPictureElement) {
+                                    await document.exitPictureInPicture();
+                                } else {
+                                    await iframe.requestPictureInPicture();
+                                }
+                            } catch (err) {
+                                console.error('Error using Picture-in-Picture:', err);
+                            }
+                        });
+                        videoPlaceholder.appendChild(pipBtn);
+                    }
                 }
             }
         });


### PR DESCRIPTION
## Summary
- allow YouTube embeds to request Picture-in-Picture and load inline
- add a small PiP button and styling for each loaded video

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896388a9bec832fb8c248fb4233ab27