### PR TITLE
feat: add feed update list button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -103,6 +103,26 @@ body {
     font-size: var(--font-size-medium);
     color: var(--secondary-text-color);
     text-align: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.feed-updates {
+    display: none;
+    position: fixed;
+    top: calc(var(--header-height) + var(--spacing-small));
+    left: calc(env(safe-area-inset-left) + var(--spacing-xlarge));
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
+    padding: var(--spacing-medium);
+    max-height: 80vh;
+    overflow-y: auto;
+    z-index: 1000;
+}
+
+.feed-updates div {
+    margin-bottom: var(--spacing-small);
 }
 
 .header-icons {

--- a/index.template.html
+++ b/index.template.html
@@ -39,13 +39,14 @@
 </head>
 <body>
     <div class="header">
-        <p class="last-updated"><!-- last_updated_placeholder --></p>
+        <button id="last-updated-button" class="last-updated"><!-- last_updated_placeholder --></button>
         <div class="header-icons">
             <span id="top-icon" class="header-icon"><i class="fas fa-arrow-up"></i></span>
             <span id="star-toggle" class="header-icon"><i class="fas fa-star"></i></span>
             <span id="refresh-icon" class="header-icon"><i class="fas fa-rotate-right"></i></span>
         </div>
     </div>
+    <div id="feed-updates" class="feed-updates"></div>
     <div id="feed-container"></div>
     <script src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const topIcon = document.getElementById('top-icon');
     const starToggle = document.getElementById('star-toggle');
     const refreshIcon = document.getElementById('refresh-icon');
+    const lastUpdatedButton = document.getElementById('last-updated-button');
+    const feedUpdatesContainer = document.getElementById('feed-updates');
+    const feedUpdateDataElement = document.getElementById('feed-update-data');
     let feedData = [];
+    let feedUpdates = [];
     let showingStarred = false;
 
     // Feed rendering and "new items" logic
@@ -14,6 +18,14 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (e) {
             console.error("Error parsing feed data:", e);
             return;
+        }
+    }
+
+    if (feedUpdateDataElement) {
+        try {
+            feedUpdates = JSON.parse(feedUpdateDataElement.textContent);
+        } catch (e) {
+            console.error("Error parsing feed update data:", e);
         }
     }
 
@@ -168,6 +180,22 @@ document.addEventListener('DOMContentLoaded', () => {
     if (refreshIcon) {
         refreshIcon.addEventListener('click', () => {
             window.location.reload();
+        });
+    }
+
+    if (lastUpdatedButton && feedUpdatesContainer) {
+        lastUpdatedButton.addEventListener('click', () => {
+            if (feedUpdatesContainer.style.display === 'block') {
+                feedUpdatesContainer.style.display = 'none';
+                return;
+            }
+
+            let html = '';
+            feedUpdates.forEach(update => {
+                html += `<div>${update.feed_title} - ${update.last_updated}</div>`;
+            });
+            feedUpdatesContainer.innerHTML = html;
+            feedUpdatesContainer.style.display = 'block';
         });
     }
 


### PR DESCRIPTION
## Summary
- turn last updated text into a button
- show sorted feed update list in a dropdown
- embed feed update data during build

## Testing
- `python -m py_compile scripts/fetch_feeds.py`
- `node -c js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_6896714da2c8832f8b2a5a1280fdeba4