### PR TITLE
Split into two footer buttons: mark-as-read and fetch-now

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,8 @@
          </div>
          <p class="last-updated">09:39</p>
          <div class="footer-right">
-             <button id="mark-all-read-btn" class="icon-btn" title="Mark as read &amp; fetch latest feeds" aria-label="Mark as read and fetch latest feeds"><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg></button>
+             <button id="fetch-now-btn" class="icon-btn" title="Fetch latest feeds now" aria-label="Fetch latest feeds now"><svg viewBox="0 0 24 24"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg></button>
+             <button id="mark-all-read-btn" class="icon-btn" title="Mark all as read and refresh" aria-label="Mark all as read and refresh"><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg></button>
          </div>
      </div>
      <script type="module" src="js/main.js"></script>

--- a/index.template.html
+++ b/index.template.html
@@ -63,7 +63,8 @@
          </div>
          <p class="last-updated"><!-- last_updated_placeholder --></p>
          <div class="footer-right">
-             <button id="mark-all-read-btn" class="icon-btn" title="Mark as read &amp; fetch latest feeds" aria-label="Mark as read and fetch latest feeds"><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg></button>
+             <button id="fetch-now-btn" class="icon-btn" title="Fetch latest feeds now" aria-label="Fetch latest feeds now"><svg viewBox="0 0 24 24"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg></button>
+             <button id="mark-all-read-btn" class="icon-btn" title="Mark all as read and refresh" aria-label="Mark all as read and refresh"><svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg></button>
          </div>
      </div>
      <div id="toast-container" class="toast-container"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -481,16 +481,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Mark all read + trigger GitHub Actions workflow + wait + reload
+    // Mark all read + reload page (no workflow trigger)
     const markAllReadBtn = document.getElementById('mark-all-read-btn');
     if (markAllReadBtn) {
         markAllReadBtn.addEventListener('click', async () => {
             if (markAllReadBtn.disabled) return;
 
-            markAllReadBtn.disabled = true;
-            markAllReadBtn.classList.add('fetching');
-
-            // Step 1: mark all current feed items as seen and sync to Gist
             const meta = gistSync.getLocal();
             meta.items = meta.items || [];
             const now = new Date().toISOString();
@@ -509,29 +505,44 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             if (changed) {
+                markAllReadBtn.disabled = true;
+                markAllReadBtn.classList.add('fetching');
                 meta.updated_at = now;
                 gistSync.setLocal(meta);
                 try {
                     await upload();
                 } catch (e) {
-                    console.warn('Gist sync before refresh failed:', e);
+                    console.warn('Final push before refresh failed:', e);
                 }
+                setTimeout(() => {
+                    window.scrollTo(0, 0);
+                    window.location.reload();
+                }, 500);
+            } else {
+                window.scrollTo(0, 0);
+                window.location.reload();
             }
+        });
+    }
 
-            // Step 2: trigger the GitHub Actions workflow if configured
+    // Fetch-now button: trigger GitHub Actions workflow, poll until done, then reload
+    const fetchNowBtn = document.getElementById('fetch-now-btn');
+    if (fetchNowBtn) {
+        fetchNowBtn.addEventListener('click', async () => {
+            if (fetchNowBtn.disabled) return;
+
             const token = localStorage.getItem('GITHUB_TOKEN');
             const repo = localStorage.getItem('GITHUB_REPO');
 
             if (!token || !repo) {
-                // No workflow configured — just reload as before
-                markAllReadBtn.disabled = false;
-                markAllReadBtn.classList.remove('fetching');
-                window.scrollTo(0, 0);
-                window.location.reload();
+                showToast('Set GitHub token and repository in Settings first', 'error', 4000);
                 return;
             }
 
+            fetchNowBtn.disabled = true;
+            fetchNowBtn.classList.add('fetching');
             showToast('Fetching latest feeds\u2026', 'info', 5000);
+
             const dispatchedAt = new Date().toISOString();
 
             try {
@@ -553,14 +564,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     throw new Error(err.message || `HTTP ${res.status}`);
                 }
 
-                // Step 3: poll until the workflow run completes, then reload
-                await pollWorkflowUntilDone(repo, token, dispatchedAt, markAllReadBtn);
+                await pollWorkflowUntilDone(repo, token, dispatchedAt, fetchNowBtn);
 
             } catch (e) {
                 console.error('Workflow dispatch failed:', e);
                 showToast(`Could not trigger refresh: ${e.message}`, 'error', 4000);
-                markAllReadBtn.disabled = false;
-                markAllReadBtn.classList.remove('fetching');
+                fetchNowBtn.disabled = false;
+                fetchNowBtn.classList.remove('fetching');
             }
         });
     }


### PR DESCRIPTION
- Checkmark button (mark-all-read-btn): marks items read, syncs to Gist, reloads the page — no workflow involvement
- Refresh/sync icon button (fetch-now-btn): triggers the GitHub Actions workflow_dispatch, spins while polling run status, reloads on success; requires GITHUB_TOKEN and GITHUB_REPO configured in Settings

https://claude.ai/code/session_01S6sNgRN7kfq8xPo8aDd7rC